### PR TITLE
Best practices update

### DIFF
--- a/checkout-page/Dockerfile
+++ b/checkout-page/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:8.1.4-alpine
 
-EXPOSE 5000
-
-WORKDIR /app
-
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm i -s --no-progress
+RUN npm i -s --no-progress && \
+    mkdir /app && \
+    cp -R ./node_modules ./app
+
+WORKDIR /app
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,29 @@
 version: '2'
 
 services:
-
   micro-frontend-docs-page:
     container_name: micro-frontend-docs-page
     build: docs-page
+    networks:
+      - local-network
     environment:
       - NODE_ENV=production
-      - PORT=3000
+      - PORT=5000
 
   micro-frontend-items-page:
     container_name: micro-frontend-items-page
     build: items-page
+    networks:
+      - local-network
     environment:
       - NODE_ENV=production
-      - PORT=4000
+      - PORT=5000
   
   micro-frontend-home-page:
     container_name: micro-frontend-home-page
     build: home-page
+    networks:
+      - local-network
     environment:
       - NODE_ENV=production
       - PORT=5000
@@ -26,9 +31,11 @@ services:
   micro-frontend-checkout-page:
     container_name: micro-frontend-checkout-page
     build: checkout-page
+    networks:
+      - local-network
     environment:
       - NODE_ENV=production
-      - PORT=6000
+      - PORT=5000
 
   micro-frontend-nginx:
     container_name: micro-frontend-nginx
@@ -37,13 +44,13 @@ services:
       - ./assets:/var/www
     ports:
       - "8888:80"
-    links:
-      - micro-frontend-home-page
-      - micro-frontend-docs-page
-      - micro-frontend-items-page
-      - micro-frontend-checkout-page
+    networks:
+      - local-network
     depends_on:
       - micro-frontend-home-page
       - micro-frontend-docs-page
       - micro-frontend-items-page
       - micro-frontend-checkout-page
+
+networks:
+  local-network:

--- a/docs-page/Dockerfile
+++ b/docs-page/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:8.1.4-alpine
 
-EXPOSE 5000
-
-WORKDIR /app
-
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm i -s --no-progress
+RUN npm i -s --no-progress && \
+    mkdir /app && \
+    cp -R ./node_modules ./app
+
+WORKDIR /app
 
 COPY . .
 

--- a/home-page/Dockerfile
+++ b/home-page/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:8.1.4-alpine
 
-EXPOSE 5000
-
-WORKDIR /app
-
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm i -s --no-progress
+RUN npm i -s --no-progress && \
+    mkdir /app && \
+    cp -R ./node_modules ./app
+
+WORKDIR /app
 
 COPY . .
 

--- a/item-page/Dockerfile
+++ b/item-page/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:8.1.4-alpine
 
-EXPOSE 5000
-
-WORKDIR /app
-
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm i -s --no-progress
+RUN npm i -s --no-progress && \
+    mkdir /app && \
+    cp -R ./node_modules ./app
+
+WORKDIR /app
 
 COPY . .
 

--- a/items-page/Dockerfile
+++ b/items-page/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:8.1.4-alpine
 
-EXPOSE 5000
-
-WORKDIR /app
-
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm i -s --no-progress
+RUN npm i -s --no-progress && \
+    mkdir /app && \
+    cp -R ./node_modules ./app
+
+WORKDIR /app
 
 COPY . .
 

--- a/nginx/configuration/default.conf
+++ b/nginx/configuration/default.conf
@@ -8,7 +8,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass http://micro-frontend-docs-page:3000;
+    proxy_pass http://micro-frontend-docs-page:5000;
   }
 
   location /items {
@@ -16,7 +16,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass http://micro-frontend-items-page:4000;
+    proxy_pass http://micro-frontend-items-page:5000;
   }
 
   location /home {
@@ -32,7 +32,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass http://micro-frontend-checkout-page:6000;
+    proxy_pass http://micro-frontend-checkout-page:5000;
   }
 
   location /static {


### PR DESCRIPTION
Just a few changes to improve your repo:

- Individual Dockerfile of the apps:
--- Removed the EXPOSE (no need to have that)
------ 1) they are not being externally exposed. Only the nginx need local access to them
------ 2) even if they need to be exposed there is no need to have that on the Dockerfile. Just expose when starting the container is fine.
--- Just a tweek on handling the npm install to improve the rebuild

- main docker-compose:
--- Set the same port (5000) to all apps: 
------ the apps are isolated containers, they can run on the same internal port (that is not the external). The nginx container is the only one that need access and as the container is running under the same network, it can access the apps just fine on the internal port.
--- Changed the "links" way of connecting containers to start using "networks":
------- that is the new way of 'linking' containers. https://docs.docker.com/network/links/ and https://docs.docker.com/compose/compose-file/#endpoint_mode

- default config of nginx:
--- updated to also have all apps under the same port (5000)